### PR TITLE
Fixed issue w/ header locations when not using frameworks in podfile.

### DIFF
--- a/Pod/Classes/SEGCleverTapIntegration.m
+++ b/Pod/Classes/SEGCleverTapIntegration.m
@@ -1,5 +1,11 @@
 #import "SEGCleverTapIntegration.h"
+
+#if defined(__has_include) && __has_include(<CleverTap-iOS-SDK/CleverTap.h>)
+#import <CleverTap-iOS-SDK/CleverTap.h>
+#else
 #import <CleverTapSDK/CleverTap.h>
+#endif
+
 #import <Analytics/SEGAnalyticsUtils.h>
 #import "SEGCleverTapIntegrationFactory.h"
 


### PR DESCRIPTION
When disabling use_frameworks in Podfile, CleverTap's SDK naming structure prevents a successful build.  I would suggest standardizing on just CleverTapSDK.  Currently, with CleverTap-iOS-SDK in the mix via the project name, it creates ambiguity which CocoaPods doesn't seem to handle very well.  When not using frameworks, file paths are used by Cocoapods rather than module names when placing headers in the Pods directory for a project.

The code changes supplied in this PR simply work around the issue by looking in the other potential location for the header at compile time.  This currently prevents customers from using CleverTap as a device mode destination with `analytics-react-native` library.  If/when this PR is merged, please tag me so that I may put out a new release of `analytics-react-native` and get our mutual customers up and running again.

Thanks so much! 🙏

Brandon @ Segment